### PR TITLE
replace CURRENTDIR for APPDIR

### DIFF
--- a/AppDir/bin/flip-exec-order.src.hook
+++ b/AppDir/bin/flip-exec-order.src.hook
@@ -6,8 +6,8 @@
 # we just allow it to get called as the first argument inside 'gnome-calculator' AppImage itself, eliminating this issue.
 
 # Check if 'gnome-calculator-search-provider' is supplied as $1, then if ARGV0 is supplied, then if $1 is supplied as binary, then if it's the main bin
-if [ -f "$CURRENTDIR"/bin/"$1" ] && [ "$1" = "gnome-calculator-search-provider" ]; then
+if [ -f "$APPDIR"/bin/"$1" ] && [ "$1" = "gnome-calculator-search-provider" ]; then
 	BIN="$1"
     shift
-	exec "$CURRENTDIR"/bin/"$BIN" "$@"
+	exec "$APPDIR"/bin/"$BIN" "$@"
 fi

--- a/AppDir/bin/search-integration.hook
+++ b/AppDir/bin/search-integration.hook
@@ -69,7 +69,7 @@ if [ -n "$APPIMAGE" ] && command -v gnome-shell 1>/dev/null && \
   echo "Name=${DBUS_SERVICE_NAME%.service}" >> "$DBUS_SHARE_LOCAL"
   echo "Exec=$APPIMAGE gnome-calculator-search-provider" >> "$DBUS_SHARE_LOCAL"
   if [ ! -f "$SEARCH_SHARE_LOCAL" ]; then
-    cp "${CURRENTDIR}/share/gnome-shell/search-providers/${SEARCH_PROVIDER_NAME}" "$SEARCH_SHARE_LOCAL"
+    cp "${APPDIR}/share/gnome-shell/search-providers/${SEARCH_PROVIDER_NAME}" "$SEARCH_SHARE_LOCAL"
   fi
   ## Fix filename for AM/appman desktop file in search provider config
   if command -v sed 1>/dev/null; then


### PR DESCRIPTION
I will be dropping `CURRENTDIR` for `APPDIR` in the AppRun, makes no sense to have two vars that do the same. 